### PR TITLE
feat: Added functionality to read files.

### DIFF
--- a/citrine/citrine.asm
+++ b/citrine/citrine.asm
@@ -4,9 +4,16 @@ section .note.GNU-stack noalloc noexec nowrite progbits
 
 section .text
     global open_file_asm
+    global read_file_asm
 
 
 open_file_asm:
     mov rax, 2
+    syscall
+    ret
+
+
+read_file_asm:
+    mov rax, 0
     syscall
     ret

--- a/citrine/citrine.c
+++ b/citrine/citrine.c
@@ -3,6 +3,7 @@
 
 
 extern int open_file_asm(const char *path, int flags, mode_t mode);
+extern ssize_t read_file_asm(int fd, void *buffer, size_t count);
 
 
 
@@ -22,4 +23,14 @@ int open_file(const char *path, int flags) {
         perror("Error opening file");
     }
     return fd;
+}
+
+
+
+ssize_t read_file(int fd, void *buffer, size_t count) {
+    ssize_t bytesRead = read_file_asm(fd, buffer, count);
+    if (bytesRead == -1) {
+        perror("Error reading file");
+    }
+    return bytesRead;
 }

--- a/citrine/citrine.h
+++ b/citrine/citrine.h
@@ -14,6 +14,7 @@ ssize_t read_file_asm(int fd, void *buffer, size_t count);
 
 int create_file(const char *path, mode_t mode);
 int open_file(const char *path, int flags);
+ssize_t read_file(int fd, void *buffer, size_t count);
 
 
 

--- a/citrine/citrine.h
+++ b/citrine/citrine.h
@@ -3,7 +3,9 @@
 
 
 #include <sys/types.h>
-#include <fcntl.h> 
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
 
 
 

--- a/citrine/citrine.h
+++ b/citrine/citrine.h
@@ -8,11 +8,13 @@
 
 
 int open_file_asm(const char *path, int flags, mode_t mode);
+ssize_t read_file_asm(int fd, void *buffer, size_t count);
 
 
 
 int create_file(const char *path, mode_t mode);
 int open_file(const char *path, int flags);
+
 
 
 #endif


### PR DESCRIPTION
This pull request adds the implementation and interface for the read_file_asm function, which is an assembly function designed to make a system call to read files. It also adds the read_file function in C, which uses read_file_asm to read files and handles possible errors.

## The files modified and added are:
- **citrine/citrine.asm:** Assembly implementation of the read_file_asm function.
- **citrine/citrine.c:** C implementation of the read_file function, which calls read_file_asm and handles read errors.
- **citrine/citrine.h:** Declarations of the read_file_asm and read_file functions.