### PR TITLE
docs: Translation of the Permissions Definition Function Documentation into Portuguese

### DIFF
--- a/docs/Portuguese/Assembly/Definir-Permissões.md
+++ b/docs/Portuguese/Assembly/Definir-Permissões.md
@@ -1,0 +1,2 @@
+# Definir Permissões
+A função `set_permissions` utiliza `set_permissions_asm` para definir as permissões de um arquivo.

--- a/docs/Portuguese/Assembly/Definir-Permissões.md
+++ b/docs/Portuguese/Assembly/Definir-Permissões.md
@@ -1,2 +1,7 @@
 # Definir Permissões
-A função `set_permissions` utiliza `set_permissions_asm` para definir as permissões de um arquivo.
+A função `set_permissions_asm` é uma implementação em assembly que realiza uma chamada de sistema para definir as permissões de um arquivo. Ela altera as permissões de um arquivo especificado por seu caminho.
+
+## Assinatura
+```c
+int set_permissions_asm(const char *path, mode_t mode);
+```

--- a/docs/Portuguese/Assembly/Definir-Permissões.md
+++ b/docs/Portuguese/Assembly/Definir-Permissões.md
@@ -13,3 +13,8 @@ int set_permissions_asm(const char *path, mode_t mode);
 #### Parâmetros
 - `path: (const char *) -` O caminho para o arquivo cujas permissões serão alteradas. Deve ser uma string terminada em nulo.
 - `mode: (mode_t) -` As novas permissões a serem definidas para o arquivo. Exemplos incluem 0666 para permissões padrão de leitura e escrita.
+
+<br>
+
+#### Retorno
+- `Retorna: (int) -` Retorna 0 se a chamada for bem-sucedida; -1 se ocorrer um erro.

--- a/docs/Portuguese/Assembly/Definir-Permissões.md
+++ b/docs/Portuguese/Assembly/Definir-Permissões.md
@@ -1,7 +1,15 @@
 # Definir Permissões
 A função `set_permissions_asm` é uma implementação em assembly que realiza uma chamada de sistema para definir as permissões de um arquivo. Ela altera as permissões de um arquivo especificado por seu caminho.
 
+<br><br>
+
 ## Assinatura
 ```c
 int set_permissions_asm(const char *path, mode_t mode);
 ```
+
+<br>
+
+#### Parâmetros
+- `path: (const char *) -` O caminho para o arquivo cujas permissões serão alteradas. Deve ser uma string terminada em nulo.
+- `mode: (mode_t) -` As novas permissões a serem definidas para o arquivo. Exemplos incluem 0666 para permissões padrão de leitura e escrita.

--- a/docs/Portuguese/Assembly/README.md
+++ b/docs/Portuguese/Assembly/README.md
@@ -1,8 +1,9 @@
 # Assembly
 
-| Arquivo                                                 | Descrição                                      |
-|---------------------------------------------------------|------------------------------------------------|
-| [Abrir e Criar Ficheiros](./Abrir-e-Criar-Ficheiros.md) | Documenta a criação e a abertura de ficheiros. |
-| [Ler Ficheiros](./Ler-Ficheiros.md)                     | Documenta a leitura de arquivos.               |
-| [Escrever Ficheiros](./Escrever-Ficheiros.md)           | Documenta a forma de escrever em ficheiros.    |
-| [Fechar Ficheiros](./Fechar-Ficheiros.md)               | Documenta a forma de fechar ficheiros.         |
+| Arquivo                                                 | Descrição                                             |
+|---------------------------------------------------------|-------------------------------------------------------|
+| [Abrir e Criar Ficheiros](./Abrir-e-Criar-Ficheiros.md) | Documenta a criação e a abertura de ficheiros.        |
+| [Ler Ficheiros](./Ler-Ficheiros.md)                     | Documenta a leitura de arquivos.                      |
+| [Escrever Ficheiros](./Escrever-Ficheiros.md)           | Documenta a forma de escrever em ficheiros.           |
+| [Fechar Ficheiros](./Fechar-Ficheiros.md)               | Documenta a forma de fechar ficheiros.                |
+| [Definir Permissões](./Definir-Permissões.md)           | Documenta a forma de definir permissões em ficheiros. |

--- a/docs/Portuguese/C/Definir-Permissões.md
+++ b/docs/Portuguese/C/Definir-Permissões.md
@@ -1,0 +1,2 @@
+# Definir Permissões
+A função `set_permissions` utiliza [`set_permissions_asm`](../Assembly/Definir-Permissões.md) para definir as permissões de um arquivo.

--- a/docs/Portuguese/C/Definir-Permissões.md
+++ b/docs/Portuguese/C/Definir-Permissões.md
@@ -7,3 +7,9 @@ A função `set_permissions` utiliza [`set_permissions_asm`](../Assembly/Definir
 ```c
 int set_permissions(const char *path, mode_t mode);
 ```
+
+<br>
+
+#### Parâmetros
+- `path: (const char *) -` O caminho para o arquivo cujas permissões serão alteradas. Deve ser uma string terminada em nulo.
+- `mode: (mode_t) -` As novas permissões a serem definidas para o arquivo. Exemplos incluem 0666 para permissões padrão de leitura e escrita.

--- a/docs/Portuguese/C/Definir-Permissões.md
+++ b/docs/Portuguese/C/Definir-Permissões.md
@@ -13,3 +13,8 @@ int set_permissions(const char *path, mode_t mode);
 #### Parâmetros
 - `path: (const char *) -` O caminho para o arquivo cujas permissões serão alteradas. Deve ser uma string terminada em nulo.
 - `mode: (mode_t) -` As novas permissões a serem definidas para o arquivo. Exemplos incluem 0666 para permissões padrão de leitura e escrita.
+
+<br>
+
+#### Retorno
+- `Retorna: (int) -` Retorna 0 se a operação for bem-sucedida; -1 se ocorrer um erro.

--- a/docs/Portuguese/C/Definir-Permissões.md
+++ b/docs/Portuguese/C/Definir-Permissões.md
@@ -1,2 +1,9 @@
 # Definir Permissões
 A função `set_permissions` utiliza [`set_permissions_asm`](../Assembly/Definir-Permissões.md) para definir as permissões de um arquivo.
+
+<br><br>
+
+## Assinatura
+```c
+int set_permissions(const char *path, mode_t mode);
+```

--- a/docs/Portuguese/C/README.md
+++ b/docs/Portuguese/C/README.md
@@ -1,9 +1,10 @@
 # C
 
-| Arquivo                                       | Descrição                                  |
-|-----------------------------------------------|--------------------------------------------|
-| [Abrir Ficheiros](./Abrir-Ficheiros.md)       | Documentação de abertura de ficheiros.     |
-| [Criar Ficheiros](./Criar-Ficheiros.md)       | Documentação de criação de ficheiros.      |
-| [Ler Ficheiros](./Ler-Ficheiros.md)           | Documentação de leitura de ficheiros.      |
-| [Escrever Ficheiros](./Escrever-Ficheiros.md) | Documentação de escrita em ficheiros.      |
-| [Fechar Ficheiros](./Fechar-Ficheiros.md)     | Documentação de encerramento de ficheiros. |
+| Arquivo                                       | Descrição                                             |
+|-----------------------------------------------|-------------------------------------------------------|
+| [Abrir Ficheiros](./Abrir-Ficheiros.md)       | Documentação de abertura de ficheiros.                |
+| [Criar Ficheiros](./Criar-Ficheiros.md)       | Documentação de criação de ficheiros.                 |
+| [Ler Ficheiros](./Ler-Ficheiros.md)           | Documentação de leitura de ficheiros.                 |
+| [Escrever Ficheiros](./Escrever-Ficheiros.md) | Documentação de escrita em ficheiros.                 |
+| [Fechar Ficheiros](./Fechar-Ficheiros.md)     | Documentação de encerramento de ficheiros.            |
+| [Definir Permissões](./Definir-Permissões.md) | Documentação de definição de permissões em ficheiros. |


### PR DESCRIPTION
This pull request includes the translation of the documentation for the set_permissions_asm and set_permissions functions into Portuguese. The translated documentation provides a detailed description of each function, including its parameters, return values and usage notes.