### PR TITLE
build: Adding CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.10)
+project(CitrineProject C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+include_directories(citrine)
+
+file(GLOB CITRINE_SOURCES "citrine/*.c")
+file(GLOB EXAMPLES_SOURCES "examples/*.c")
+file(GLOB CITRINE_HEADERS "citrine/*.h")
+file(GLOB EXAMPLES_HEADERS "examples/*.h")
+file(GLOB CITRINE_ASM "citrine/*.asm")
+file(GLOB EXAMPLES_ASM "examples/*.asm")
+
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR})
+
+set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
+
+set(SOURCES ${CITRINE_SOURCES} ${EXAMPLES_SOURCES})
+set(ASM_SOURCES ${CITRINE_ASM} ${EXAMPLES_ASM})
+
+foreach(asm_file ${ASM_SOURCES})
+    get_filename_component(asm_name ${asm_file} NAME_WE)
+    set(asm_obj ${CMAKE_BINARY_DIR}/${asm_name}.o)
+    add_custom_command(
+        OUTPUT ${asm_obj}
+        COMMAND nasm -f elf64 -o ${asm_obj} ${asm_file}
+        DEPENDS ${asm_file}
+        COMMENT "Assembling ${asm_file}"
+    )
+    list(APPEND ASM_OBJECTS ${asm_obj})
+endforeach()
+
+add_executable(citrine_executable ${SOURCES} ${ASM_OBJECTS})
+
+set_target_properties(citrine_executable PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+add_custom_target(assemble ALL
+    DEPENDS ${ASM_OBJECTS}
+)
+add_dependencies(citrine_executable assemble)

--- a/citrine/citrine.c
+++ b/citrine/citrine.c
@@ -78,3 +78,4 @@ int set_permissions(const char *path, mode_t mode) {
     }
     
     return result;
+}


### PR DESCRIPTION
This pull request updates the CMakeLists.txt file to correctly configure the Citrine project, adding support for compiling C and assembly files. The main changes include:

- **Project Definition:** Added the CitrineProject project with support for the C language, using the C11 standard.
- **Directories and Files:**
    - Included directives to locate C and assembly source and header files in the citrine and examples directories.
    - The source code and header files for the project have been defined.
- **Assembly compilation:**
    - Configured CMake to generate object files from assembly files using nasm.
    - Added custom compilation steps for .asm files, with the generated objects being included in the final build of the executable.
- **Executable configuration:**
    - Defined the name of the executable as citrine_executable.
    - Configured the directive for the executable to be placed in the build directory.
- **Assembly target:**
    - Added a custom assembly target that depends on the object files generated from the assembly files.