### PR TITLE
docs: Add Documentation and Examples for _unlinkFile Function.

### DIFF
--- a/docs/English/Assembly/CloseFiles.md
+++ b/docs/English/Assembly/CloseFiles.md
@@ -47,7 +47,6 @@ section .text
 
 
 _start:
-    ; Abrir o arquivo 
     mov rdi, file_path
     mov rsi, 0x41
     mov rdx, 0644

--- a/docs/English/Assembly/README.md
+++ b/docs/English/Assembly/README.md
@@ -7,3 +7,4 @@
 | [Write Files](./WriteFiles.md)                      | Documentation on writing in files.            |
 | [Close Files](./Close-Files.md)                     | Documentation on how to close files.          |
 | [Set Permissions](./SetPermissions.md)              | Documentation on adding permissions to files. |
+| [Remove File](./RemoveFiles.md)                     | Documentation for removing files.             |

--- a/docs/English/Assembly/RemoveFiles.md
+++ b/docs/English/Assembly/RemoveFiles.md
@@ -1,0 +1,2 @@
+# _unlinkFile
+The _unlinkFile function removes a file from the file system in Linux using the unlink syscall. When called, the function unlinks the specified file name from its inode, effectively deleting the file from the system if this is the last link to the inode.

--- a/docs/English/Assembly/RemoveFiles.md
+++ b/docs/English/Assembly/RemoveFiles.md
@@ -59,3 +59,10 @@ error:
     xor rdi, rdi
     syscall
 ```
+
+<br><br>
+
+## Additional Notes:
+- The _unlinkFile function removes the link to a file from the file system. If the file is the only link to the inode, disk space is freed.
+- The code above assumes that the file to be removed exists and that you have the necessary permissions to delete it.
+- On critical systems, it is recommended to perform additional checks before removing files, such as backups or user commits.

--- a/docs/English/Assembly/RemoveFiles.md
+++ b/docs/English/Assembly/RemoveFiles.md
@@ -25,3 +25,37 @@ _unlinkFile:
 
 #### Return Value:
 - **rax:** If the syscall is successful, rax will contain 0. In case of error, rax will contain a negative value corresponding to the error code.
+
+<br><br>
+
+## Example of use:
+This example demonstrates how to use _unlinkFile to delete a file from the file system.
+
+```asm
+section .data
+    file_path db 'example.txt', 0
+
+
+
+section .text
+    global _start
+    extern _unlinkFile
+
+
+_start:
+    mov rdi, file_path
+    call _unlinkFile
+
+    test rax, rax
+    js error
+
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+
+error:
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+```

--- a/docs/English/Assembly/RemoveFiles.md
+++ b/docs/English/Assembly/RemoveFiles.md
@@ -1,2 +1,17 @@
 # _unlinkFile
 The _unlinkFile function removes a file from the file system in Linux using the unlink syscall. When called, the function unlinks the specified file name from its inode, effectively deleting the file from the system if this is the last link to the inode.
+
+<br><br>
+
+## Implementation Details:
+- **Syscall Number:** 87
+- **Registers Used:**
+    - `rax:` Stores the syscall number.
+    - `rdi:` Pointer to the string containing the path of the file to be removed.
+
+```asm
+_unlinkFile:
+    mov rax, 87
+    syscall
+    ret
+```

--- a/docs/English/Assembly/RemoveFiles.md
+++ b/docs/English/Assembly/RemoveFiles.md
@@ -20,3 +20,8 @@ _unlinkFile:
 
 #### Expected Parameters:
 - **rdi:** Pointer to the string containing the path of the file that will be removed.
+
+<br>
+
+#### Return Value:
+- **rax:** If the syscall is successful, rax will contain 0. In case of error, rax will contain a negative value corresponding to the error code.

--- a/docs/English/Assembly/RemoveFiles.md
+++ b/docs/English/Assembly/RemoveFiles.md
@@ -15,3 +15,8 @@ _unlinkFile:
     syscall
     ret
 ```
+
+<br>
+
+#### Expected Parameters:
+- **rdi:** Pointer to the string containing the path of the file that will be removed.

--- a/docs/Portuguese/Assembly/FecharFicheiros.md
+++ b/docs/Portuguese/Assembly/FecharFicheiros.md
@@ -47,7 +47,6 @@ section .text
 
 
 _start:
-    ; Abrir o arquivo 
     mov rdi, file_path
     mov rsi, 0x41
     mov rdx, 0644

--- a/docs/Portuguese/Assembly/README.md
+++ b/docs/Portuguese/Assembly/README.md
@@ -7,3 +7,4 @@
 | [Escrever Ficheiros](./EscreverFicheiros.md)            | Documenta a forma de escrever em ficheiros.           |
 | [Fechar Ficheiros](./FecharFicheiros.md)                | Documenta a forma de fechar ficheiros.                |
 | [Definir Permissões](./DefinirPermissões.md)            | Documenta a forma de definir permissões em ficheiros. |
+| [Remover Ficheiros](./RemoverFicheiros.md)              | Documenta a forma de remover ficheiros.               |

--- a/docs/Portuguese/Assembly/RemoverFicheiros.md
+++ b/docs/Portuguese/Assembly/RemoverFicheiros.md
@@ -25,3 +25,37 @@ _unlinkFile:
 
 #### Valor de Retorno:
 - **rax:** Se a syscall for bem-sucedida, rax conterá 0. Em caso de erro, rax conterá um valor negativo correspondente ao código de erro.
+
+<br><br>
+
+## Exemplo de Uso:
+Este exemplo demonstra como usar _unlinkFile para deletar um arquivo do sistema de arquivos.
+
+```asm
+section .data
+    file_path db 'example.txt', 0
+
+
+
+section .text
+    global _start
+    extern _unlinkFile
+
+
+_start:
+    mov rdi, file_path
+    call _unlinkFile
+
+    test rax, rax
+    js error
+
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+
+error:
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+```

--- a/docs/Portuguese/Assembly/RemoverFicheiros.md
+++ b/docs/Portuguese/Assembly/RemoverFicheiros.md
@@ -8,3 +8,15 @@ A função _unlinkFile remove um arquivo do sistema de arquivos no Linux utiliza
 - **Registradores Utilizados:**
     - `rax:` Armazena o número da syscall.
     - `rdi:` Ponteiro para a string contendo o caminho do arquivo a ser removido.
+
+```asm
+_unlinkFile:
+    mov rax, 87
+    syscall
+    ret
+```
+
+<br>
+
+#### Parâmetros Esperados:
+- **rdi:** Ponteiro para a string contendo o caminho do arquivo que será removido.

--- a/docs/Portuguese/Assembly/RemoverFicheiros.md
+++ b/docs/Portuguese/Assembly/RemoverFicheiros.md
@@ -1,0 +1,2 @@
+# _unlinkFile
+A função _unlinkFile remove um arquivo do sistema de arquivos no Linux utilizando a syscall unlink. Ao ser chamada, a função desvincula o nome do arquivo especificado de seu inode, efetivamente deletando o arquivo do sistema se este for o último link para o inode.

--- a/docs/Portuguese/Assembly/RemoverFicheiros.md
+++ b/docs/Portuguese/Assembly/RemoverFicheiros.md
@@ -20,3 +20,8 @@ _unlinkFile:
 
 #### Parâmetros Esperados:
 - **rdi:** Ponteiro para a string contendo o caminho do arquivo que será removido.
+
+<br>
+
+#### Valor de Retorno:
+- **rax:** Se a syscall for bem-sucedida, rax conterá 0. Em caso de erro, rax conterá um valor negativo correspondente ao código de erro.

--- a/docs/Portuguese/Assembly/RemoverFicheiros.md
+++ b/docs/Portuguese/Assembly/RemoverFicheiros.md
@@ -59,3 +59,10 @@ error:
     xor rdi, rdi
     syscall
 ```
+
+<br><br>
+
+## Notas Adicionais:
+- A função _unlinkFile remove o link de um arquivo do sistema de arquivos. Se o arquivo for o único link para o inode, o espaço em disco será liberado.
+- O código acima assume que o arquivo a ser removido existe e que você tem as permissões necessárias para deletá-lo.
+- Em sistemas críticos, é recomendável realizar verificações adicionais antes de remover arquivos, como backups ou confirmações do usuário.

--- a/docs/Portuguese/Assembly/RemoverFicheiros.md
+++ b/docs/Portuguese/Assembly/RemoverFicheiros.md
@@ -1,2 +1,10 @@
 # _unlinkFile
 A função _unlinkFile remove um arquivo do sistema de arquivos no Linux utilizando a syscall unlink. Ao ser chamada, a função desvincula o nome do arquivo especificado de seu inode, efetivamente deletando o arquivo do sistema se este for o último link para o inode.
+
+<br><br>
+
+## Detalhes da Implementação:
+- **Syscall Número:** 87
+- **Registradores Utilizados:**
+    - `rax:` Armazena o número da syscall.
+    - `rdi:` Ponteiro para a string contendo o caminho do arquivo a ser removido.

--- a/examples/Assembly/close_file.asm
+++ b/examples/Assembly/close_file.asm
@@ -13,7 +13,6 @@ section .text
 
 
 _start:
-    ; Abrir o arquivo 
     mov rdi, file_path
     mov rsi, 0x41
     mov rdx, 0644

--- a/examples/Assembly/remove_file.asm
+++ b/examples/Assembly/remove_file.asm
@@ -1,0 +1,26 @@
+section .data
+    file_path db 'example.txt', 0
+
+
+
+section .text
+    global _start
+    extern _unlinkFile
+
+
+_start:
+    mov rdi, file_path
+    call _unlinkFile
+
+    test rax, rax
+    js error
+
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+
+error:
+    mov rax, 60
+    xor rdi, rdi
+    syscall


### PR DESCRIPTION
This pull request introduces detailed documentation for the _unlinkFile function in our project. The documentation includes:

- **Function Description:** A clear explanation of what the _unlinkFile function does.
- **Usage Details:** An overview of the syscall used and the expected parameters.
- **Return Values:** Information on what values are returned by the function.
- **Example:** A comprehensive example demonstrating the usage of the function, including:
    - **_Removing a File:_** Using _unlinkFile to delete a file from the filesystem.
    - **_Error Handling:_** Basic error checking after attempting to remove the file.

Additionally, the examples have been provided in Assembly (.asm) format to facilitate easy copy-pasting and usage.