### PR TITLE
docs: Add Documentation and Examples for _accessFile Function.

### DIFF
--- a/docs/English/Assembly/AccessFile.md
+++ b/docs/English/Assembly/AccessFile.md
@@ -68,3 +68,38 @@ error:
     xor rdi, rdi
     syscall
 ```
+
+<br>
+
+#### Check if the File is Readable
+This example demonstrates how to use _accessFile to check whether a file is readable. 
+
+```asm
+section .data
+    file_path db 'example.txt', 0
+
+
+
+section .text
+    global _start
+    extern _accessFile
+
+
+_start:
+    mov rdi, file_path
+    mov rsi, 4
+    call _accessFile
+    
+    test rax, rax
+    js error
+
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+
+error:
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+```

--- a/docs/English/Assembly/AccessFile.md
+++ b/docs/English/Assembly/AccessFile.md
@@ -103,3 +103,9 @@ error:
     xor rdi, rdi
     syscall
 ```
+
+<br><br>
+
+## Additional Notes:
+- The _accessFile function is useful for checking the existence and permissions of files before trying to open or manipulate them. However, due to possible race conditions, access checking does not guarantee that the subsequent operation (such as opening the file) will be successful.
+- The use of appropriate flags is essential to verify the correct type of access.

--- a/docs/English/Assembly/AccessFile.md
+++ b/docs/English/Assembly/AccessFile.md
@@ -20,9 +20,14 @@ _accessFile:
 <br>
 
 #### Expected Parameters:
-- rdi: Pointer to the string containing the path of the file to be checked.
-- rsi: Accessibility check flags. Common values ​​include:
+- **rdi:** Pointer to the string containing the path of the file to be checked.
+- **rsi:** Accessibility check flags. Common values ​​include:
     - **0:** Checks the existence of the file.
     - **1:** Checks if the file is executable.
     - **2:** Checks if the file is writable.
     - **4:** Checks if the file is readable.
+
+<br>
+
+#### Return Value:
+- **rax:** If the syscall is successful (i.e. if access is allowed), rax will contain 0. In case of error (e.g. if access is denied or the file does not exist), rax will contain a corresponding negative value to the error code.

--- a/docs/English/Assembly/AccessFile.md
+++ b/docs/English/Assembly/AccessFile.md
@@ -31,3 +31,40 @@ _accessFile:
 
 #### Return Value:
 - **rax:** If the syscall is successful (i.e. if access is allowed), rax will contain 0. In case of error (e.g. if access is denied or the file does not exist), rax will contain a corresponding negative value to the error code.
+
+<br><br>
+
+## Example of use:
+
+#### Check for the Existence of a File
+This example demonstrates how to use _accessFile to check whether a file exists on the file system.
+
+```asm
+section .data
+    file_path db 'example.txt', 0
+
+
+
+section .text
+    global _start
+    extern _accessFile
+
+
+_start:
+    mov rdi, file_path
+    mov rsi, 0
+    call _accessFile
+    
+    test rax, rax
+    js error
+
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+
+error:
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+```

--- a/docs/English/Assembly/AccessFile.md
+++ b/docs/English/Assembly/AccessFile.md
@@ -1,2 +1,18 @@
 # _accessFile
 The _accessFile function checks the accessibility of a file on the Linux file system using the access syscall. This function can be used to check whether a file exists and/or whether the process has the necessary permissions to perform specific operations (read, write, execute) on the file.
+
+<br><br>
+
+## Implementation Details:
+- **Syscall Number:** 21
+- **Registers Used:**
+    - `rax:` Stores the syscall number.
+    - `rdi:` Pointer to the string containing the file path.
+    - `rsi:` Flags that indicate the type of access to be checked.
+
+```asm
+_accessFile:
+    mov rax, 21
+    syscall
+    ret
+```

--- a/docs/English/Assembly/AccessFile.md
+++ b/docs/English/Assembly/AccessFile.md
@@ -16,3 +16,13 @@ _accessFile:
     syscall
     ret
 ```
+
+<br>
+
+#### Expected Parameters:
+- rdi: Pointer to the string containing the path of the file to be checked.
+- rsi: Accessibility check flags. Common values ​​include:
+    - **0:** Checks the existence of the file.
+    - **1:** Checks if the file is executable.
+    - **2:** Checks if the file is writable.
+    - **4:** Checks if the file is readable.

--- a/docs/English/Assembly/AccessFile.md
+++ b/docs/English/Assembly/AccessFile.md
@@ -1,0 +1,2 @@
+# _accessFile
+The _accessFile function checks the accessibility of a file on the Linux file system using the access syscall. This function can be used to check whether a file exists and/or whether the process has the necessary permissions to perform specific operations (read, write, execute) on the file.

--- a/docs/English/Assembly/README.md
+++ b/docs/English/Assembly/README.md
@@ -1,10 +1,11 @@
 # Assembly
 
-| Archive                                             | Description                                   |
-|-----------------------------------------------------|-----------------------------------------------|
-| [Open and Create Files](./OpenFiles.md)             | Documents the creation and opening of files.  |
-| [Read Files](./ReadFiles.md)                        | Documentation on reading files                |
-| [Write Files](./WriteFiles.md)                      | Documentation on writing in files.            |
-| [Close Files](./Close-Files.md)                     | Documentation on how to close files.          |
-| [Set Permissions](./SetPermissions.md)              | Documentation on adding permissions to files. |
-| [Remove File](./RemoveFiles.md)                     | Documentation for removing files.             |
+| Archive                                 | Description                                                                             |
+|-----------------------------------------|-----------------------------------------------------------------------------------------|
+| [Open and Create Files](./OpenFiles.md) | Documents the creation and opening of files.                                            |
+| [Read Files](./ReadFiles.md)            | Documentation on reading files                                                          |
+| [Write Files](./WriteFiles.md)          | Documentation on writing in files.                                                      |
+| [Close Files](./Close-Files.md)         | Documentation on how to close files.                                                    |
+| [Set Permissions](./SetPermissions.md)  | Documentation on adding permissions to files.                                           |
+| [Remove File](./RemoveFiles.md)         | Documentation for removing files.                                                       |
+| [Access File](./AccessFile.md)          | Documentation of the function that checks the existence of files and their permissions. |

--- a/docs/Portuguese/Assembly/AcessarFicheiros.md
+++ b/docs/Portuguese/Assembly/AcessarFicheiros.md
@@ -26,3 +26,8 @@ _accessFile:
     - **1:** Verifica se o arquivo é executável.
     - **2:** Verifica se o arquivo é gravável.
     - **4:** Verifica se o arquivo é legível.
+
+<br>
+
+#### Valor de Retorno:
+- **rax:** Se a syscall for bem-sucedida (ou seja, se o acesso for permitido), rax conterá 0. Em caso de erro (por exemplo, se o acesso for negado ou o arquivo não existir), rax conterá um valor negativo correspondente ao código de erro.

--- a/docs/Portuguese/Assembly/AcessarFicheiros.md
+++ b/docs/Portuguese/Assembly/AcessarFicheiros.md
@@ -103,3 +103,9 @@ error:
     xor rdi, rdi
     syscall
 ```
+
+<br><br>
+
+## Notas Adicionais:
+- A função _accessFile é útil para verificar a existência e permissões de arquivos antes de tentar abri-los ou manipulá-los. No entanto, devido a possíveis condições de corrida, a verificação do acesso não garante que a operação subsequente (como abrir o arquivo) será bem-sucedida.
+- O uso de flags apropriadas é essencial para verificar o tipo correto de acesso.

--- a/docs/Portuguese/Assembly/AcessarFicheiros.md
+++ b/docs/Portuguese/Assembly/AcessarFicheiros.md
@@ -1,0 +1,2 @@
+# _accessFile
+A função _accessFile verifica a acessibilidade de um arquivo no sistema de arquivos Linux usando a syscall access. Essa função pode ser utilizada para verificar se um arquivo existe e/ou se o processo tem as permissões necessárias para realizar operações específicas (leitura, escrita, execução) no arquivo.

--- a/docs/Portuguese/Assembly/AcessarFicheiros.md
+++ b/docs/Portuguese/Assembly/AcessarFicheiros.md
@@ -31,3 +31,38 @@ _accessFile:
 
 #### Valor de Retorno:
 - **rax:** Se a syscall for bem-sucedida (ou seja, se o acesso for permitido), rax conterá 0. Em caso de erro (por exemplo, se o acesso for negado ou o arquivo não existir), rax conterá um valor negativo correspondente ao código de erro.
+
+## Exemplos de Uso:
+
+#### Verificar a Existência de um Arquivo
+Este exemplo demonstra como usar _accessFile para verificar se um arquivo existe no sistema de arquivos.
+
+```asm
+section .data
+    file_path db 'example.txt', 0
+
+
+
+section .text
+    global _start
+    extern _accessFile
+
+
+_start:
+    mov rdi, file_path
+    mov rsi, 0
+    call _accessFile
+    
+    test rax, rax
+    js error
+
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+
+error:
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+```

--- a/docs/Portuguese/Assembly/AcessarFicheiros.md
+++ b/docs/Portuguese/Assembly/AcessarFicheiros.md
@@ -16,3 +16,13 @@ _accessFile:
     syscall
     ret
 ```
+
+<br>
+
+#### Parâmetros Esperados:
+- **rdi:** Ponteiro para a string contendo o caminho do arquivo que será verificado.
+- **rsi:** Flags de verificação de acessibilidade. Valores comuns incluem:
+    - **0:** Verifica a existência do arquivo.
+    - **1:** Verifica se o arquivo é executável.
+    - **2:** Verifica se o arquivo é gravável.
+    - **4:** Verifica se o arquivo é legível.

--- a/docs/Portuguese/Assembly/AcessarFicheiros.md
+++ b/docs/Portuguese/Assembly/AcessarFicheiros.md
@@ -32,6 +32,8 @@ _accessFile:
 #### Valor de Retorno:
 - **rax:** Se a syscall for bem-sucedida (ou seja, se o acesso for permitido), rax conterá 0. Em caso de erro (por exemplo, se o acesso for negado ou o arquivo não existir), rax conterá um valor negativo correspondente ao código de erro.
 
+<br><br>
+
 ## Exemplos de Uso:
 
 #### Verificar a Existência de um Arquivo
@@ -51,6 +53,41 @@ section .text
 _start:
     mov rdi, file_path
     mov rsi, 0
+    call _accessFile
+    
+    test rax, rax
+    js error
+
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+
+error:
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+```
+
+<br>
+
+#### Verificar se o Arquivo é Legível
+Este exemplo demonstra como usar _accessFile para verificar se um arquivo é legível.
+
+```asm
+section .data
+    file_path db 'example.txt', 0
+
+
+
+section .text
+    global _start
+    extern _accessFile
+
+
+_start:
+    mov rdi, file_path
+    mov rsi, 4
     call _accessFile
     
     test rax, rax

--- a/docs/Portuguese/Assembly/AcessarFicheiros.md
+++ b/docs/Portuguese/Assembly/AcessarFicheiros.md
@@ -1,2 +1,18 @@
 # _accessFile
 A função _accessFile verifica a acessibilidade de um arquivo no sistema de arquivos Linux usando a syscall access. Essa função pode ser utilizada para verificar se um arquivo existe e/ou se o processo tem as permissões necessárias para realizar operações específicas (leitura, escrita, execução) no arquivo.
+
+<br><br>
+
+## Detalhes da Implementação:
+- **Syscall Número:** 21
+- **Registradores Utilizados:**
+    - `rax:` Armazena o número da syscall.
+    - `rdi:` Ponteiro para a string contendo o caminho do arquivo.
+    - `rsi:` Flags que indicam o tipo de acesso a ser verificado.
+
+```asm
+_accessFile:
+    mov rax, 21
+    syscall
+    ret
+```

--- a/docs/Portuguese/Assembly/README.md
+++ b/docs/Portuguese/Assembly/README.md
@@ -1,10 +1,11 @@
 # Assembly
 
-| Arquivo                                                 | Descrição                                             |
-|---------------------------------------------------------|-------------------------------------------------------|
-| [Abrir e Criar Ficheiros](./AbrirFicheiros.md)          | Documenta a criação e a abertura de ficheiros.        |
-| [Ler Ficheiros](./LerFicheiros.md)                      | Documenta a leitura de arquivos.                      |
-| [Escrever Ficheiros](./EscreverFicheiros.md)            | Documenta a forma de escrever em ficheiros.           |
-| [Fechar Ficheiros](./FecharFicheiros.md)                | Documenta a forma de fechar ficheiros.                |
-| [Definir Permissões](./DefinirPermissões.md)            | Documenta a forma de definir permissões em ficheiros. |
-| [Remover Ficheiros](./RemoverFicheiros.md)              | Documenta a forma de remover ficheiros.               |
+| Arquivo                                                 | Descrição                                                                       |
+|---------------------------------------------------------|---------------------------------------------------------------------------------|
+| [Abrir e Criar Ficheiros](./AbrirFicheiros.md)          | Documenta a criação e a abertura de ficheiros.                                  |
+| [Ler Ficheiros](./LerFicheiros.md)                      | Documenta a leitura de arquivos.                                                |
+| [Escrever Ficheiros](./EscreverFicheiros.md)            | Documenta a forma de escrever em ficheiros.                                     |
+| [Fechar Ficheiros](./FecharFicheiros.md)                | Documenta a forma de fechar ficheiros.                                          |
+| [Definir Permissões](./DefinirPermissões.md)            | Documenta a forma de definir permissões em ficheiros.                           |
+| [Remover Ficheiros](./RemoverFicheiros.md)              | Documenta a forma de remover ficheiros.                                         |
+| [Acessar Ficheiros](./AcessarFicheiros.md)              | Documentação da função que verifica a existência de arquivos e suas permissões. |

--- a/examples/Assembly/file_exists.asm
+++ b/examples/Assembly/file_exists.asm
@@ -1,0 +1,27 @@
+section .data
+    file_path db 'example.txt', 0
+
+
+
+section .text
+    global _start
+    extern _accessFile
+
+
+_start:
+    mov rdi, file_path
+    mov rsi, 0
+    call _accessFile
+    
+    test rax, rax
+    js error
+
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+
+error:
+    mov rax, 60
+    xor rdi, rdi
+    syscall

--- a/examples/Assembly/verify_permissions.asm
+++ b/examples/Assembly/verify_permissions.asm
@@ -1,0 +1,27 @@
+section .data
+    file_path db 'example.txt', 0
+
+
+
+section .text
+    global _start
+    extern _accessFile
+
+
+_start:
+    mov rdi, file_path
+    mov rsi, 4
+    call _accessFile
+    
+    test rax, rax
+    js error
+
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+
+error:
+    mov rax, 60
+    xor rdi, rdi
+    syscall


### PR DESCRIPTION
This pull request introduces detailed documentation for the _accessFile function in our project. The documentation includes:

- **Function Description:** A clear explanation of what the _accessFile function does.
- **Usage Details:** An overview of the syscall used and the expected parameters.
- **Return Values:** Information on what values are returned by the function.
- **Examples:** Two separate examples demonstrating the usage of the function:
    - **_Checking File Existence:_** Using _accessFile to verify if a file exists.
    - **_Checking File Readability:_** Verifying if a file is readable using the appropriate flag.
    - **_Error Handling:_** Basic error checking after attempting to verify access.
    
Additionally, the examples have been provided in Assembly (.asm) format to facilitate easy copy-pasting and usage.